### PR TITLE
Fix: PCSX2 extension

### DIFF
--- a/system/templates/emulationstation/es_systems.batocera.cfg
+++ b/system/templates/emulationstation/es_systems.batocera.cfg
@@ -1192,7 +1192,7 @@
 	<manufacturer>Sony</manufacturer>
     <hardware>console</hardware>
     <path>~\..\roms\ps2</path>
-    <extension>.iso .ISO .cso .CSO .bin .BIN .mds .MDS .gz .GZ</extension>
+    <extension>.iso .ISO .cso .CSO .bin .BIN .mdf .MDF .gz .GZ</extension>
     <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
 	  <!--<emulator name="angle">

--- a/system/templates/emulationstation/es_systems.d3d.cfg
+++ b/system/templates/emulationstation/es_systems.d3d.cfg
@@ -1192,7 +1192,7 @@
 	<manufacturer>Sony</manufacturer>
     <hardware>console</hardware>
     <path>~\..\roms\ps2</path>
-    <extension>.iso .ISO .cso .CSO .bin .BIN .mds .MDS .gz .GZ</extension>
+    <extension>.iso .ISO .cso .CSO .bin .BIN .mdf .MDF .gz .GZ</extension>
     <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
 	  <emulator name="angle">

--- a/system/templates/emulationstation/es_systems.default.cfg
+++ b/system/templates/emulationstation/es_systems.default.cfg
@@ -1192,7 +1192,7 @@
 	<manufacturer>Sony</manufacturer>
     <hardware>console</hardware>
     <path>~\..\roms\ps2</path>
-    <extension>.iso .ISO .cso .CSO .bin .BIN .mds .MDS .gz .GZ</extension>
+    <extension>.iso .ISO .cso .CSO .bin .BIN .mdf .MDF .gz .GZ</extension>
     <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
 	  <!--<emulator name="angle">

--- a/system/templates/emulationstation/es_systems.opengl.cfg
+++ b/system/templates/emulationstation/es_systems.opengl.cfg
@@ -1192,7 +1192,7 @@
 	<manufacturer>Sony</manufacturer>
     <hardware>console</hardware>
     <path>~\..\roms\ps2</path>
-    <extension>.iso .ISO .cso .CSO .bin .BIN .mds .MDS .gz .GZ</extension>
+    <extension>.iso .ISO .cso .CSO .bin .BIN .mdf .MDF .gz .GZ</extension>
     <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
 	  <!--<emulator name="angle">


### PR DESCRIPTION
Fix ps2 extension for Achool 120% the emulator reconizes MDF not MDS