### PR TITLE
Add new Systems : Philips-CDI, Adventure Vision, TV Games, Megaduck, …

### DIFF
--- a/system/templates/emulationstation/es_features.cfg
+++ b/system/templates/emulationstation/es_features.cfg
@@ -8,6 +8,48 @@
     </feature>
   </globalFeatures>
   <emulator name="libretro, angle" features="autocontrollers, ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation, videomode">
+    <system name="fm7">
+      <feature name="MODEL TO EMULATE" value="altmodel" description="Type of FM-7 to emulate">
+        <choice name="FM-7" value="fm7"/>
+        <choice name="FM-77AV" value="fm7av"/>
+      </feature>
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette" value="cass"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Disk (Drive 2)" value="flop2"/>
+      </feature>
+    </system>
+    <system name="bbcmicro">
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette" value="cass"/>
+        <choice name="ROM (Slot 1)" value="rom1"/>
+        <choice name="ROM (Slot 2)" value="rom2"/>
+        <choice name="ROM (Slot 3)" value="rom3"/>
+        <choice name="ROM (Slot 4)" value="rom4"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Disk (Drive 2)" value="flop2"/>
+      </feature>
+    </system>
+    <system name="adam">
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette 1" value="cass1"/>
+        <choice name="Cassette 2" value="cass2"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Disk (Drive 2)" value="flop2"/>
+        <choice name="Cartridge (Slot 1)" value="cart1"/>
+        <choice name="Cartridge (Slot 2)" value="cart2"/>
+        <choice name="Cartridge (Slot 3)" value="cart3"/>
+        <choice name="Cartridge (Slot 4)" value="cart4"/>
+      </feature>
+    </system>
+    <system name="ti99">
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette 1" value="cass1"/>
+        <choice name="Cassette 2" value="cass2"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Cartridge" value="cart"/>
+      </feature>
+    </system>
     <core name="atari2600" features="rewind, autosave"/>
     <core name="atari5200" features="rewind, autosave"/>
     <core name="atari7800" features="rewind, autosave"/>
@@ -437,15 +479,15 @@
         <choice name="2880x2160" value="2880x2160"/>
         <choice name="3840x2160" value="3840x2160"/>
       </feature>
-      <feature name="BOOT FROM CLI" value="boot_from_cli">
+      <feature submenu="BOOT OPTIONS" name="BOOT FROM CLI" value="boot_from_cli">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
-      <feature name="BOOT TO BIOS" value="boot_to_bios">
+      <feature submenu="BOOT OPTIONS" name="BOOT TO BIOS" value="boot_to_bios">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
-      <feature name="BOOT TO OSD" value="boot_to_osd">
+      <feature submenu="BOOT OPTIONS" name="BOOT TO OSD" value="boot_to_osd">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
@@ -1019,14 +1061,14 @@
     <core name="nestopia" features="netplay, rewind, autosave"/>
     <core name="np2kai" features="netplay, rewind, autosave, padtokeyboard"/>
     <core name="nxengine" features="rewind, autosave"/>
-    <core name="o2em" features="rewind, autosave"/>
+    <core name="o2em" features="rewind, cheevos, autosave"/>
     <core name="opera" features="cheevos, netplay, rewind, autosave"/>
     <core name="parallel_n64" features="cheevos, netplay, rewind, autosave"/>
     <core name="pce" features="netplay, rewind, autosave"/>
-    <core name="pcfx" features="netplay, rewind, autosave"/>
+    <core name="pcfx" features="netplay, rewind, cheevos, autosave"/>
     <core name="pocketsnes" features="netplay, rewind, autosave"/>
     <core name="pokemini" features="cheevos, rewind, autosave"/>
-    <core name="ppsspp" features="autosave">
+    <core name="ppsspp" features="cheevos, autosave">
       <feature name="INTERNAL RESOLUTION" value="ppsspp_internal_resolution" description="Improve the resolution at the cost of increased performance requirements.">
         <choice name="1x" value="480x272"/>
         <choice name="2x" value="960x544"/>
@@ -1185,7 +1227,7 @@
 	  <choice name="RETROBAT (FRONTEND)" value="true"/>
       <choice name="EMULATOR (CONFIG)" value="false"/>
     </feature>-->
-    <feature name="VIDEO DRIVER" value="video_driver" description="Some libretro cores will try to force the video driver matching what they want.">
+    <feature submenu="RETROARCH VIDEO DRIVER" name="VIDEO DRIVER" value="video_driver" description="Some libretro cores will try to force the video driver matching what they want.">
       <choice name="OPENGL" value="gl"/>
       <choice name="GL CORE" value="glcore"/>
       <choice name="DIRECTX 9" value="d3d9"/>
@@ -1194,7 +1236,7 @@
       <choice name="DIRECTX 12" value="d3d12"/>
       <choice name="VULKAN" value="vulkan"/>
     </feature>
-    <feature name="MONITOR INDEX" value="MonitorIndex" description="Games will be displayed on the monitor corresponding to the selected index.">
+    <feature submenu="RETROARCH VIDEO DRIVER" name="MONITOR INDEX" value="MonitorIndex" description="Games will be displayed on the monitor corresponding to the selected index.">
       <choice name="CONFIG" value="config"/>
       <choice name="0" value="0"/>
       <choice name="1" value="1"/>
@@ -1400,7 +1442,7 @@
     <feature name="CRC HACKS" value="crc_hack_level" description="Controls the number of Auto-CRC fixes and hacks applied to games.">
       <choice name="AGRESSIVE" value="4"/>
     </feature>
-    <feature name="SPEED HACKS" value="negdivhack" description="Significantly improves performances for CPU with 3+ cores.">
+    <feature name="FPU COMPATIBILITY HACK" value="negdivhack" description="Apply NegDivHack patch">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>
     </feature>
@@ -1471,11 +1513,11 @@
       <choice name="VULKAN" value="Vulkan"/>
       <choice name="DIRECTX 11" value="D3D"/>
       <choice name="DIRECTX 12" value="D3D12"/>
-    </feature>	
-	<feature name="CONTROLLER BUTTONS" value="gamepadbuttons" description="Set the button position convention.">
+    </feature>
+    <feature name="CONTROLLER BUTTONS" value="gamepadbuttons" description="Set the button position convention.">
       <choice name="ORGINAL" value="0"/>
       <choice name="INVERTS A AND B, Y AND X" value="1"/>
-    </feature>	
+    </feature>
     <system name="wii" features="emulated_wiimotes"/>
   </emulator>
   <emulator name="dolphin-triforce" features="autocontrollers, videomode"/>
@@ -1666,7 +1708,50 @@
   <emulator name="cemu" features="autocontrollers, videomode, padtokeyboard"/>
   <emulator name="teknoparrot" features="autocontrollers"/>
   <emulator name="mame" features="videomode"/>
-  <emulator name="mame64" features="videomode"/>
+  <emulator name="mame64" features="videomode, padtokeyboard">
+    <system name="fm7">
+      <feature name="MODEL TO EMULATE" value="altmodel" description="Type of FM-7 to emulate">
+        <choice name="FM-7" value="fm7"/>
+        <choice name="FM-77AV" value="fm7av"/>
+      </feature>
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette" value="cass"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Disk (Drive 2)" value="flop2"/>
+      </feature>
+    </system>
+    <system name="bbcmicro">
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette" value="cass"/>
+        <choice name="ROM (Slot 1)" value="rom1"/>
+        <choice name="ROM (Slot 2)" value="rom2"/>
+        <choice name="ROM (Slot 3)" value="rom3"/>
+        <choice name="ROM (Slot 4)" value="rom4"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Disk (Drive 2)" value="flop2"/>
+      </feature>
+    </system>
+    <system name="adam">
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette 1" value="cass1"/>
+        <choice name="Cassette 2" value="cass2"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Disk (Drive 2)" value="flop2"/>
+        <choice name="Cartridge (Slot 1)" value="cart1"/>
+        <choice name="Cartridge (Slot 2)" value="cart2"/>
+        <choice name="Cartridge (Slot 3)" value="cart3"/>
+        <choice name="Cartridge (Slot 4)" value="cart4"/>
+      </feature>
+    </system>
+    <system name="ti99">
+      <feature name="MEDIA TYPE" value="altromtype" description="Type of ROM file">
+        <choice name="Cassette 1" value="cass1"/>
+        <choice name="Cassette 2" value="cass2"/>
+        <choice name="Disk (Drive 1)" value="flop1"/>
+        <choice name="Cartridge" value="cart"/>
+      </feature>
+    </system>
+  </emulator>
   <emulator name="applewin" features="padtokeyboard"/>
   <emulator name="gsplus" features="padtokeyboard"/>
   <emulator name="arcadeflashweb" features="videomode, padtokeyboard"/>
@@ -1701,5 +1786,5 @@
       <choice name="OPENGL" value="0"/>
       <choice name="VULKAN" value="1"/>
     </feature>
-  </emulator>  
+  </emulator>
 </features>

--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -3072,6 +3072,30 @@
       </emulator>
     </emulators>
   </system>
+  <system>
+    <name>vsmile</name>
+    <fullname>V.Smile</fullname>
+    <manufacturer>VTech</manufacturer>
+    <release>2004</release>
+    <hardware>console</hardware>
+    <path>~\..\roms\vsmile</path>
+    <extension>.bin .zip</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="mame64">
+        <cores>
+          <core>vsmile</core>
+        </cores>
+      </emulator>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>vsmile</platform>
+    <theme>vsmile</theme>
+  </system>  
   <!--<system>
     <name>medias</name>
     <fullname>Medias</fullname>

--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -3082,14 +3082,14 @@
     <extension>.bin .zip</extension>
     <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-      <emulator name="mame64">
-        <cores>
-          <core>vsmile</core>
-        </cores>
-      </emulator>
       <emulator name="libretro">
         <cores>
           <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>vsmile</core>
         </cores>
       </emulator>
     </emulators>

--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -37,7 +37,7 @@
           <!--<core>hbmame</core>-->
           <core>mame2016</core>
           <core>mame2003_plus</core>
-		  <core>mame2003_midway</core>
+          <core>mame2003_midway</core>
           <core>flycast</core>
         </cores>
       </emulator>
@@ -60,7 +60,7 @@
       <emulator name="libretro">
         <cores>
           <core>mame2003_plus</core>
-		  <core>mame2003_midway</core>
+          <core>mame2003_midway</core>
           <core>mame2016</core>
           <core>mame</core>
         </cores>
@@ -81,10 +81,10 @@
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
-        <cores>          
+        <cores>
           <core>mame</core>
-		  <core>mame2003_plus</core>
-		  <core>mame2003_midway</core>
+          <core>mame2003_plus</core>
+          <core>mame2003_midway</core>
           <core>mame2016</core>
         </cores>
       </emulator>
@@ -106,7 +106,7 @@
       <emulator name="libretro">
         <cores>
           <core>mame2003_plus</core>
-		  <core>mame2003_midway</core>
+          <core>mame2003_midway</core>
           <core>mame2016</core>
           <core>mame</core>
           <core>flycast</core>
@@ -206,7 +206,7 @@
     <name>cps1</name>
     <fullname>CPS-I</fullname>
     <manufacturer>Capcom</manufacturer>
-	<release>1988</release>
+    <release>1988</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\cps1</path>
     <extension>.fba .zip .FBA .ZIP .7z</extension>
@@ -214,7 +214,7 @@
     <emulators>
       <emulator name="libretro">
         <cores>
-		  <core default="true">fbalpha2012_cps1</core>
+          <core default="true">fbalpha2012_cps1</core>
           <core>fbneo</core>
           <core>fbalpha2012</core>
         </cores>
@@ -227,7 +227,7 @@
     <name>cps2</name>
     <fullname>CPS-II</fullname>
     <manufacturer>Capcom</manufacturer>
-	<release>1993</release>
+    <release>1993</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\cps2</path>
     <extension>.fba .zip .FBA .ZIP .7z</extension>
@@ -248,7 +248,7 @@
     <name>cps3</name>
     <fullname>CPS-III</fullname>
     <manufacturer>Capcom</manufacturer>
-	<release>1996</release>
+    <release>1996</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\cps3</path>
     <extension>.fba .zip .FBA .ZIP .7z</extension>
@@ -269,7 +269,7 @@
     <name>neogeo</name>
     <fullname>Neo Geo</fullname>
     <manufacturer>SNK</manufacturer>
-	<release>1991</release>
+    <release>1991</release>
     <hardware>console</hardware>
     <path>~\..\roms\neogeo</path>
     <extension>.zip .ZIP .wad .7z .7Z .WAD</extension>
@@ -290,7 +290,7 @@
     <name>neogeocd</name>
     <fullname>Neo Geo CD</fullname>
     <manufacturer>SNK</manufacturer>
-	<release>1994</release>
+    <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\neogeocd</path>
     <extension>.txt .TXT .m3u .M3U .cue .CUE .iso .ISO .cso .CSO .chd .CHD .zip .ZIP .7z .7Z</extension>
@@ -311,7 +311,7 @@
     <name>model2</name>
     <fullname>Model 2</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1994</release>
+    <release>1994</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\model2</path>
     <extension>.zip .ZIP</extension>
@@ -331,7 +331,7 @@
     <name>model3</name>
     <fullname>Model 3</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1996</release>
+    <release>1996</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\model3</path>
     <extension>.zip .ZIP</extension>
@@ -347,7 +347,7 @@
     <fullname>Atomiswave</fullname>
     <path>~\..\roms\atomiswave</path>
     <manufacturer>Sammy</manufacturer>
-	<release>2003</release>
+    <release>2003</release>
     <hardware>arcade</hardware>
     <extension>.bin .lst .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
@@ -368,7 +368,7 @@
     <name>naomi</name>
     <fullname>Naomi</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1999</release>
+    <release>1999</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\naomi</path>
     <extension>.bin .dat .lst .zip</extension>
@@ -390,7 +390,7 @@
     <name>naomi2</name>
     <fullname>Naomi 2</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>2001</release>
+    <release>2001</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\naomi2</path>
     <extension>.zip .ZIP</extension>
@@ -407,7 +407,7 @@
     <name>hikaru</name>
     <fullname>Hikaru</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1999</release>
+    <release>1999</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\hikaru</path>
     <extension>.zip</extension>
@@ -440,14 +440,14 @@
     <name>chihiro</name>
     <fullname>Chihiro</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>2003</release>
+    <release>2003</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\chihiro</path>
     <extension>.xbe .XBE .iso .ISO</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="chihiro"/>
-	  <emulator name="xemu"/>
+      <emulator name="xemu"/>
     </emulators>
     <platform>arcade</platform>
     <theme>chihiro</theme>
@@ -456,7 +456,7 @@
     <name>triforce</name>
     <fullname>Triforce</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>2003</release>
+    <release>2003</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\triforce</path>
     <extension>.iso .ISO .zip .ZIP .cue .CUE</extension>
@@ -476,7 +476,7 @@
     <name>sg1000</name>
     <fullname>SG-1000</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1983</release>
+    <release>1983</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\sg1000</path>
     <extension>.sms .gg .sg .bin .rom .zip .7z .SMS .GG .SG .BIN .ROM .ZIP .7Z</extension>
@@ -496,7 +496,7 @@
     <name>mastersystem</name>
     <fullname>Master System - Mark III</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1985</release>
+    <release>1985</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\mastersystem</path>
     <extension>.bin .BIN .sms .wad .WAD .SMS .zip .ZIP .7z .7Z</extension>
@@ -523,7 +523,7 @@
     <name>megadrive</name>
     <fullname>Megadrive - Genesis</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1988</release>
+    <release>1988</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\megadrive</path>
     <extension>.68k .68K .sgd .SGD .smd .bin .gen .md .sg .wad .WAD .SMD .BIN .GEN .MD .SG .zip .ZIP .7z .7Z</extension>
@@ -532,7 +532,7 @@
       <emulator name="libretro">
         <cores>
           <core>genesis_plus_gx</core>
-		  <core>genesis_plus_gx_wide</core>
+          <core>genesis_plus_gx_wide</core>
           <core>picodrive</core>
           <core>fbneo</core>
         </cores>
@@ -557,7 +557,7 @@
     <name>segacd</name>
     <fullname>Mega CD</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1991</release>
+    <release>1991</release>
     <hardware>extension</hardware>
     <path>~\..\roms\segacd</path>
     <extension>.cue .CUE .iso .ISO .cso .CSO .zip .ZIP .7z .7Z .chd .CHD</extension>
@@ -566,7 +566,7 @@
       <emulator name="libretro">
         <cores>
           <core>genesis_plus_gx</core>
-		  <core>genesis_plus_gx_wide</core>
+          <core>genesis_plus_gx_wide</core>
           <core>picodrive</core>
         </cores>
       </emulator>
@@ -584,7 +584,7 @@
     <name>sega32x</name>
     <fullname>32X</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1994</release>
+    <release>1994</release>
     <hardware>extension</hardware>
     <path>~\..\roms\sega32x</path>
     <extension>.32x .smd .bin .md .32X .SMD .BIN .MD .zip .ZIP .7z .7Z</extension>
@@ -608,7 +608,7 @@
     <name>saturn</name>
     <fullname>Saturn</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1995</release>
+    <release>1995</release>
     <hardware>console</hardware>
     <path>~\..\roms\saturn</path>
     <extension>.zip .cue .toc .m3u .ccd .chd .CUE .TOC .M3U .CCD .CHD .iso .ISO .cso .CSO .mdf .MDF .chd .CHD</extension>
@@ -628,7 +628,7 @@
     <name>dreamcast</name>
     <fullname>Dreamcast</fullname>
     <manufacturer>Sega</manufacturer>
-	<release>1998</release>
+    <release>1998</release>
     <hardware>console</hardware>
     <path>~\..\roms\dreamcast</path>
     <extension>.mds .MDS .mdf .MDF .cue .CUE .cdi .CDI .gdi .GDI .chd .CHD .m3u .M3U</extension>
@@ -724,7 +724,7 @@
           <core>snes9x</core>
           <core>bsnes</core>
           <core>bsnes_hd_beta</core>
-		  <!--<core>higan_sfc</core>-->
+          <!--<core>higan_sfc</core>-->
           <core>mednafen_snes</core>
           <core>mesen-s</core>
         </cores>
@@ -753,7 +753,7 @@
         <cores>
           <core>snes9x</core>
           <core>bsnes</core>
-		  <core>bsnes_hd_beta</core>
+          <core>bsnes_hd_beta</core>
         </cores>
       </emulator>
       <emulator name="snes9x"/>
@@ -794,7 +794,7 @@
       <emulator name="libretro">
         <cores>
           <core>snes9x</core>
-		  <core>bsnes</core>
+          <core>bsnes</core>
         </cores>
       </emulator>
     </emulators>
@@ -872,9 +872,9 @@
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="dolphin">
-	  <cores>
-        <core default="true">dolphin</core>
-	  </cores>
+        <cores>
+          <core default="true">dolphin</core>
+        </cores>
       </emulator>
       <emulator name="libretro">
         <cores>
@@ -897,8 +897,8 @@
     <emulators>
       <emulator name="dolphin">
         <cores>
-        <core default="true">dolphin</core>
-	  </cores>
+          <core default="true">dolphin</core>
+        </cores>
       </emulator>
       <emulator name="libretro">
         <cores>
@@ -979,7 +979,7 @@
         <cores>
           <core>mednafen_pce</core>
           <core>mednafen_pce_fast</core>
-		  <core>fbneo</core>
+          <core>fbneo</core>
         </cores>
       </emulator>
       <emulator name="mednafen">
@@ -1066,14 +1066,14 @@
     <extension>.iso .ISO .cso .CSO .bin .BIN .mdf .MDF .gz .GZ</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-	<emulator name="pcsx2">
-	  <cores>
-	    <core>avx2</core>
-		<core>sse2</core>
-		<core>sse4</core>
-	  </cores>
-	</emulator>
-	<!--<emulator name="libretro">
+      <emulator name="pcsx2">
+        <cores>
+          <core>avx2</core>
+          <core>sse2</core>
+          <core>sse4</core>
+        </cores>
+      </emulator>
+      <!--<emulator name="libretro">
         <cores>
           <core>pcsx2</core>
         </cores>
@@ -1107,7 +1107,7 @@
     <extension>.xbe .XBE .iso .ISO .pc .PC</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-	  <emulator name="xemu"/>
+      <emulator name="xemu"/>
       <emulator name="cxbx"/>
     </emulators>
     <platform>xbox</platform>
@@ -1189,7 +1189,7 @@
           <core>puae</core>
         </cores>
       </emulator>
-	  <emulator name="amigaforever"/>
+      <emulator name="amigaforever"/>
       <emulator name="winuae"/>
     </emulators>
     <platform>amiga</platform>
@@ -1209,12 +1209,12 @@
     <theme>amiga4000</theme>
     <group>Amiga</group>
     <emulators>
-	  <emulator name="libretro">
+      <emulator name="libretro">
         <cores>
           <core>puae</core>
         </cores>
       </emulator>
-	  <emulator name="amigaforever"/>
+      <emulator name="amigaforever"/>
       <emulator name="winuae"/>
     </emulators>
   </system>
@@ -1233,7 +1233,7 @@
           <core>puae</core>
         </cores>
       </emulator>
-	  <emulator name="amigaforever"/>
+      <emulator name="amigaforever"/>
       <emulator name="winuae">
         <core>cd32</core>
       </emulator>
@@ -1257,7 +1257,7 @@
           <core>puae</core>
         </cores>
       </emulator>
-	  <emulator name="amigaforever"/>
+      <emulator name="amigaforever"/>
     </emulators>
     <platform>amigacdtv</platform>
     <theme>amigacdtv</theme>
@@ -1532,7 +1532,7 @@
           <core>vice_xplus4</core>
           <core>vice_xvic</core>
           <core>vice_xpet</core>
-		  <core>frodo</core>
+          <core>frodo</core>
         </cores>
       </emulator>
     </emulators>
@@ -1557,30 +1557,6 @@
     </emulators>
     <platform>c64</platform>
     <theme>c128</theme>
-  </system>
-  <system>
-    <fullname>Fujitsu FM-TOWNS</fullname>
-    <name>fmtowns</name>
-    <path>~\..\roms\fmtowns</path>
-    <manufacturer>Fujitsu</manufacturer>
-    <release>1987</release>
-    <hardware>computer</hardware>
-    <extension>.d88 .d77 .xdf .cue .iso .game .cd .bin .m3u .D88 .D77 .XDF .CUE .ISO .GAME .CD .BIN .M3U</extension>
-    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -rom %ROM%</command>
-    <platform>fmtowns</platform>
-    <theme>fmtowns</theme>
-    <emulators>
-      <emulator name="tsugaru">
-        <cores>
-          <core>tsugaru</core>
-        </cores>
-      </emulator>
-	  <emulator name="mame64">
-        <cores>
-          <core>fmtownsux</core>
-        </cores>
-      </emulator>
-    </emulators>
   </system>
   <system>
     <name>intellivision</name>
@@ -1969,7 +1945,7 @@
       <emulator name="libretro">
         <cores>
           <core default="true">gw</core>
-		  <core>mame</core>
+          <core>mame</core>
         </cores>
       </emulator>
     </emulators>
@@ -1990,7 +1966,7 @@
         <cores>
           <core>gambatte</core>
           <core>mesen-s</core>
-		  <core>bsnes</core>
+          <core>bsnes</core>
           <core>tgbdual</core>
         </cores>
       </emulator>
@@ -2131,12 +2107,12 @@
     <extension>.3ds .3dsx .elf .axf .cci .cxi .app .3DS .3DSX .ELF .AXF .CCI .CXI .APP</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-	<emulator name="libretro">
+      <emulator name="libretro">
         <cores>
           <core default="true">citra</core>
         </cores>
       </emulator>
-	  <emulator name="citra">
+      <emulator name="citra">
         <cores>
           <core>citra-qt</core>
         </cores>
@@ -2160,7 +2136,7 @@
           <core>ppsspp</core>
         </cores>
       </emulator>
-	  <emulator name="ppsspp"/>
+      <emulator name="ppsspp"/>
     </emulators>
     <platform>psp</platform>
     <theme>psp</theme>
@@ -2316,7 +2292,7 @@
     <name>lutro</name>
     <fullname>Lutro Lua Framework</fullname>
     <manufacturer>Ports</manufacturer>
-    <release />
+    <release/>
     <hardware>port</hardware>
     <path>~\..\roms\lutro</path>
     <extension>.love .LOVE .lua .LUA .lutro .LUTRO .zip .ZIP .7z .7Z</extension>
@@ -2334,8 +2310,8 @@
   <system>
     <name>easyrpg</name>
     <fullname>EasyRPG - RPG Maker 2000/2003 player</fullname>
-	<manufacturer>Ports</manufacturer>
-	<release />
+    <manufacturer>Ports</manufacturer>
+    <release/>
     <hardware>port</hardware>
     <path>~\..\roms\easyrpg</path>
     <extension>.zip .easyrpg .ZIP .EASYRPG .lbd .LBD</extension>
@@ -2348,7 +2324,7 @@
       </emulator>
     </emulators>
     <platform>easyrpg</platform>
-	<group>ports</group>
+    <group>ports</group>
     <theme>easyrpg</theme>
   </system>
   <system>
@@ -2356,7 +2332,7 @@
     <fullname>PrBoom</fullname>
     <hardware>port</hardware>
     <manufacturer>Ports</manufacturer>
-    <release />
+    <release/>
     <path>~\..\roms\prboom</path>
     <extension>.wad .iwad .pwad .WAD .IWAD .PWAD</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
@@ -2430,7 +2406,7 @@
     <fullname>Openbor</fullname>
     <hardware>port</hardware>
     <manufacturer>Ports</manufacturer>
-    <release />
+    <release/>
     <path>~\..\roms\openbor</path>
     <extension>.pak .PAK .exe .EXE</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
@@ -2449,13 +2425,13 @@
     <name>solarus</name>
     <fullname>Solarus</fullname>
     <manufacturer>Ports</manufacturer>
-    <release />
+    <release/>
     <hardware>port</hardware>
     <path>~\..\roms\solarus</path>
     <extension>.solarus .SOLARUS .zip .ZIP</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-      <emulator name="solarus" />
+      <emulator name="solarus"/>
     </emulators>
     <platform>solarus</platform>
     <theme>solarus</theme>
@@ -2472,7 +2448,7 @@
     <platform>arcade</platform>
     <theme>teknoparrot</theme>
     <emulators>
-      <emulator name="teknoparrot" />
+      <emulator name="teknoparrot"/>
     </emulators>
   </system>
   <system>
@@ -2487,11 +2463,11 @@
     <emulators>
       <emulator name="libretro">
         <cores>
-		  <core>dosbox_pure</core>
+          <core>dosbox_pure</core>
         </cores>
       </emulator>
-	  <emulator name="dosbox"/>
-	  <!--<emulator name="dosbox-x"/>-->
+      <emulator name="dosbox"/>
+      <!--<emulator name="dosbox-x"/>-->
     </emulators>
     <platform>pc</platform>
     <theme>pc</theme>
@@ -2509,7 +2485,7 @@
     <theme>windows</theme>
     <emulators>
       <emulator name="windows"/>
-	  <emulator name="specific-launcher" command="%ROM%"/>
+      <emulator name="specific-launcher" command="%ROM%"/>
     </emulators>
   </system>
   <system>
@@ -2559,7 +2535,7 @@
     <hardware>pinball</hardware>
     <path>~\..\roms\pinballfx3</path>
     <extension>.pxp .PXP</extension>
-	<command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="pinballfx3">
         <cores>
@@ -2567,7 +2543,7 @@
         </cores>
       </emulator>
     </emulators>
-    <group>pinballfx</group>	
+    <group>pinballfx</group>
     <platform>pinball</platform>
     <theme>pinballfx3</theme>
   </system>
@@ -2581,9 +2557,9 @@
     <extension>.png .p8 .PNG .P8 .exe .EXE</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-	<emulator name="libretro">
+      <emulator name="libretro">
         <cores>
-		  <core>retro8</core>
+          <core>retro8</core>
         </cores>
       </emulator>
       <emulator name="pico8"/>
@@ -2601,14 +2577,500 @@
     <extension>.tic .TIC</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-	<emulator name="libretro">
+      <emulator name="libretro">
         <cores>
-		  <core>tic80</core>
+          <core>tic80</core>
         </cores>
       </emulator>
-	</emulators>
+    </emulators>
     <platform>ignore</platform>
     <theme>tic80</theme>
+  </system>
+  <system>
+    <name>cdi</name>
+    <fullname>Philips CD-i</fullname>
+    <manufacturer>Philips</manufacturer>
+    <release>1990</release>
+    <hardware>console</hardware>
+    <path>~\..\roms\cdi</path>
+    <extension>.chd .cue .toc .nrg .gdi .iso .cdr</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="mame64">
+        <cores>
+          <core>mame64</core>
+        </cores>
+      </emulator>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>cdi</platform>
+    <theme>cdi</theme>
+  </system>
+  <system>
+    <fullname>Adventure Vision</fullname>
+    <name>advision</name>
+    <path>~\..\roms\advision</path>
+    <manufacturer>Entex</manufacturer>
+    <release>1982</release>
+    <hardware>console</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>advision</platform>
+    <theme>advision</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>advision</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>TV Games</fullname>
+    <name>tvgames</name>
+    <path>~\..\roms\tvgames</path>
+    <manufacturer>Various</manufacturer>
+    <release>2002</release>
+    <hardware>console</hardware>
+    <extension>.zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>tvgames</platform>
+    <theme>tvgames</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>tvgames</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>Mega Duck</fullname>
+    <name>megaduck</name>
+    <path>~\..\roms\tvgames</path>
+    <manufacturer>Welback Holdings</manufacturer>
+    <release>1993</release>
+    <hardware>portable</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>megaduck</platform>
+    <theme>megaduck</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>megaduck</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>PV-1000</fullname>
+    <name>pv1000</name>
+    <path>~\..\roms\pv1000</path>
+    <manufacturer>Casio</manufacturer>
+    <release>1983</release>
+    <hardware>console</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>pv1000</platform>
+    <theme>pv1000</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>pv1000</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>CreatiVision</fullname>
+    <name>crvision</name>
+    <path>~\..\roms\crvision</path>
+    <manufacturer>VTech</manufacturer>
+    <release>1982</release>
+    <hardware>console</hardware>
+    <extension>.bin .rom .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>creativision</platform>
+    <theme>creativision</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>crvision</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>Game.com</fullname>
+    <name>gamecom</name>
+    <path>~\..\roms\gamecom</path>
+    <manufacturer>Tiger Electronics</manufacturer>
+    <release>1997</release>
+    <hardware>portable</hardware>
+    <extension>.bin .zip .7z .tgc</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>gamecom</platform>
+    <theme>gamecom</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>gamecom</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>Game Pocket Computer</fullname>
+    <name>gamepock</name>
+    <path>~\..\roms\gamepock</path>
+    <manufacturer>Epoch</manufacturer>
+    <release>1984</release>
+    <hardware>portable</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>gamepock</platform>
+    <theme>gamepock</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>gamepock</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <name>fm7</name>
+    <fullname>FM-7</fullname>
+    <manufacturer>Fujitsu</manufacturer>
+    <release>1982</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\fm7</path>
+    <extension>.wav .t77 .mfi .dfi .hfe .mfm .td0 .imd .d77 .d88 .1dd .cqm .cqi .dsk .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="mame64">
+        <cores>
+          <core>fm7</core>
+        </cores>
+      </emulator>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>fm7</platform>
+    <theme>fm7</theme>
+  </system>
+  <system>
+    <name>apfm1000</name>
+    <fullname>APF M-1000</fullname>
+    <manufacturer>APF Electronics</manufacturer>
+    <release>1978</release>
+    <hardware>console</hardware>
+    <path>~\..\roms\apfm1000</path>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>apfm1000</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>apfm1000</platform>
+    <theme>apfm1000</theme>
+  </system>
+  <system>
+    <name>bbcmicro</name>
+    <fullname>BBC Micro</fullname>
+    <manufacturer>Acorn</manufacturer>
+    <release>1981</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\bbcmicro</path>
+    <extension>.zip .7zip</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>bbcmicro</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>bbcmicro</platform>
+    <theme>bbcmicro</theme>
+  </system>
+  <system>
+    <name>adam</name>
+    <fullname>Coleco ADAM</fullname>
+    <manufacturer>Coleco</manufacturer>
+    <release>1983</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\adam</path>
+    <extension>.wav .ddp .mfi .dfi .hfe .mfm .td0 .imd .d77 .d88 .1dd .cqm .cqi .dsk .rom .col .bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>adam</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>ti99</platform>
+    <theme>ti99</theme>
+  </system>
+  <system>
+    <fullname>Arcadia 2001</fullname>
+    <name>arcadia</name>
+    <path>~\..\roms\arcadia</path>
+    <manufacturer>Emerson</manufacturer>
+    <release>1982</release>
+    <hardware>console</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>arcadia</platform>
+    <theme>arcadia</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>arcadia</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>Game Master</fullname>
+    <name>gmaster</name>
+    <path>~\..\roms\gmaster</path>
+    <manufacturer>Hartung</manufacturer>
+    <release>1990</release>
+    <hardware>portable</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>gmaster</platform>
+    <theme>gmaster</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>gmaster</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>Astrocade</fullname>
+    <name>astrocde</name>
+    <path>~\..\roms\astrocde</path>
+    <manufacturer>Bally</manufacturer>
+    <release>1978</release>
+    <hardware>console</hardware>
+    <extension>.bin .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>astrocde</platform>
+    <theme>astrocde</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>astrocde</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <name>ti99</name>
+    <fullname>TI/99</fullname>
+    <manufacturer>Texas Instruments</manufacturer>
+    <release>1999</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\ti99</path>
+    <extension>.zip</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>mame64</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>ti99</platform>
+    <theme>ti99</theme>
+  </system>
+  <system>
+    <name>tutor</name>
+    <fullname>Tomy Tutor</fullname>
+    <manufacturer>Tomy</manufacturer>
+    <release>1983</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\tutor</path>
+    <extension>.bin .wav .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>tutor</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>tutor</platform>
+    <theme>tutor</theme>
+  </system>
+  <system>
+    <name>coco</name>
+    <fullname>Color Computer</fullname>
+    <manufacturer>Tandy Radio Shack</manufacturer>
+    <release>1980</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\coco</path>
+    <extension>.wav .cas .ccc .rom .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>coco</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>coco</platform>
+    <theme>coco</theme>
+  </system>
+  <system>
+    <fullname>FM Towns</fullname>
+    <name>fmtowns</name>
+    <path>~\..\roms\fmtowns</path>
+    <manufacturer>Fujitsu</manufacturer>
+    <release>1987</release>
+    <hardware>computer</hardware>
+    <extension>.m3u .d88 .d77 .xdf .cue .iso .game .cd</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>fmtowns</platform>
+    <theme>fmtowns</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="tsugaru">
+        <cores>
+          <core>tsugaru</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>fmtownsux</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <fullname>LCD Games</fullname>
+    <name>lcdgames</name>
+    <path>~\..\roms\lcdgames</path>
+    <manufacturer>Various</manufacturer>
+    <release>1979</release>
+    <hardware>portable</hardware>
+    <extension>.mgw .zip .7z</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>lcdgames</platform>
+    <theme>lcdgames</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core incompatible_extensions=".mgw">mame</core>
+          <core>gw</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>lcdgames</core>
+        </cores>
+      </emulator>
+    </emulators>
   </system>
   <!--<system>
     <name>medias</name>


### PR DESCRIPTION
+ Added : Philips-CDI, Adventure Vision, TV Games, Megaduck, PV-1000, CreatiVision, Game.com, Game Pocket Computer, FM-7, APF M-1000, BBC Micro, Coleco ADAM, Arcadia 2001, Game Master, Astrocade, TI/99, Tomy Tutor, Color Computer, LCD Games 

+ Updated : FM Towns to make it work with mame64 & libretro/mame