### PR TITLE
Add camplynx, supracan, gamate, uzebox, cannonball, multivision. Disable Adam + more

### DIFF
--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -2871,8 +2871,8 @@
         </cores>
       </emulator>
     </emulators>
-    <platform>ti99</platform>
-    <theme>ti99</theme>
+    <platform>adam</platform>
+    <theme>adam</theme>
   </system>
   <system>
     <fullname>Arcadia 2001</fullname>

--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -2823,10 +2823,10 @@
     </emulators>
   </system>
   <system>
-    <fullname>Epoch Game Pocket Computer</fullname>
+    <fullname>Game Pocket Computer</fullname>
     <name>gamepock</name>
     <path>~\..\roms\gamepock</path>
-    <manufacturer>Various</manufacturer>
+    <manufacturer>Epoch Co</manufacturer>
     <release>1984</release>
     <hardware>portable</hardware>
     <extension>.bin .zip .7z</extension>
@@ -2846,6 +2846,30 @@
       </emulator>
     </emulators>
   </system>
+  <system>
+    <name>scv</name>
+    <fullname>Super Cassette Vision</fullname>
+    <manufacturer>Epoch Co</manufacturer>
+    <release>1984</release>
+    <hardware>console</hardware>
+    <path>~\..\roms\scv</path>
+    <extension>.bin .zip</extension>
+    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+	  <emulator name="mame64">
+        <cores>
+          <core>camplynx</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>scv</platform>
+    <theme>scv</theme>
+  </system>  
   <system>
     <name>fm7</name>
     <fullname>FM-7</fullname>

--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -3,12 +3,12 @@
 <systemList>
   <system>
     <name>flash</name>
-    <fullname>flash</fullname>
-    <manufacturer>Adobe</manufacturer>
+    <fullname>Adobe Flash</fullname>
+    <manufacturer>Various</manufacturer>
     <release/>
     <hardware>computer</hardware>
     <path>~\..\roms\flash</path>
-    <extension>.swf .SWF</extension>
+    <extension>.swf</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="arcadeflashweb"/>
@@ -23,7 +23,7 @@
     <release/>
     <hardware>arcade</hardware>
     <path>~\..\roms\arcade</path>
-    <extension>.fba .zip .FBA .chd .CHD .ZIP .7z .7Z .bin .BIN</extension>
+    <extension>.fba .zip .chd .7z .bin</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -54,7 +54,7 @@
     <release/>
     <hardware>arcade</hardware>
     <path>~\..\roms\mame</path>
-    <extension>.zip .ZIP .7z .7Z</extension>
+    <extension>.zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -77,7 +77,7 @@
     <release/>
     <hardware>arcade</hardware>
     <path>~\..\roms\hbmame</path>
-    <extension>.zip .ZIP .7z .7Z</extension>
+    <extension>.zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -100,7 +100,7 @@
     <release/>
     <hardware>arcade</hardware>
     <path>~\..\roms\lightgun</path>
-    <extension>.zip .ZIP .7z .7Z</extension>
+    <extension>.zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -124,7 +124,7 @@
     <release/>
     <hardware>arcade</hardware>
     <path>~\..\roms\fba</path>
-    <extension>.fba .zip .FBA .chd .CHD .ZIP .7z  .bin .BIN</extension>
+    <extension>.fba .zip .chd .7z .bin</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -145,7 +145,7 @@
     <release/>
     <hardware>arcade</hardware>
     <path>~\..\roms\fbneo</path>
-    <extension>.fba .zip .FBA .chd .CHD .ZIP .7z  .bin .BIN</extension>
+    <extension>.fba .zip .chd .7z .bin</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -166,7 +166,7 @@
     <release>1995</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\cave</path>
-    <extension>.fba .zip .FBA .ZIP .7z</extension>
+    <extension>.fba .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -230,7 +230,7 @@
     <release>1993</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\cps2</path>
-    <extension>.fba .zip .FBA .ZIP .7z</extension>
+    <extension>.fba .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -251,7 +251,7 @@
     <release>1996</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\cps3</path>
-    <extension>.fba .zip .FBA .ZIP .7z</extension>
+    <extension>.fba .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -272,7 +272,7 @@
     <release>1991</release>
     <hardware>console</hardware>
     <path>~\..\roms\neogeo</path>
-    <extension>.zip .ZIP .wad .7z .7Z .WAD</extension>
+    <extension>.zip .wad .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -293,7 +293,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\neogeocd</path>
-    <extension>.txt .TXT .m3u .M3U .cue .CUE .iso .ISO .cso .CSO .chd .CHD .zip .ZIP .7z .7Z</extension>
+    <extension>.txt .m3u .cue .iso .cso .chd .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -314,7 +314,7 @@
     <release>1994</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\model2</path>
-    <extension>.zip .ZIP</extension>
+    <extension>.zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="model2">
@@ -334,7 +334,7 @@
     <release>1996</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\model3</path>
-    <extension>.zip .ZIP</extension>
+    <extension>.zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="supermodel"/>
@@ -393,7 +393,7 @@
     <release>2001</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\naomi2</path>
-    <extension>.zip .ZIP</extension>
+    <extension>.zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="demul">
@@ -443,7 +443,7 @@
     <release>2003</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\chihiro</path>
-    <extension>.xbe .XBE .iso .ISO</extension>
+    <extension>.xbe .iso</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="chihiro"/>
@@ -459,7 +459,7 @@
     <release>2003</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\triforce</path>
-    <extension>.iso .ISO .zip .ZIP .cue .CUE</extension>
+    <extension>.iso .zip .cue</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="dolphin">
@@ -479,7 +479,7 @@
     <release>1983</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\sg1000</path>
-    <extension>.sms .gg .sg .bin .rom .zip .7z .SMS .GG .SG .BIN .ROM .ZIP .7Z</extension>
+    <extension>.sms .gg .sg .bin .rom .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -499,7 +499,7 @@
     <release>1985</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\mastersystem</path>
-    <extension>.bin .BIN .sms .wad .WAD .SMS .zip .ZIP .7z .7Z</extension>
+    <extension>.bin .sms .wad .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -526,7 +526,7 @@
     <release>1988</release>
     <hardware>arcade</hardware>
     <path>~\..\roms\megadrive</path>
-    <extension>.68k .68K .sgd .SGD .smd .bin .gen .md .sg .wad .WAD .SMD .BIN .GEN .MD .SG .zip .ZIP .7z .7Z</extension>
+    <extension>.68k .sgd .smd .bin .gen .md .sg .wad .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -560,14 +560,14 @@
     <release>1991</release>
     <hardware>extension</hardware>
     <path>~\..\roms\segacd</path>
-    <extension>.cue .CUE .iso .ISO .cso .CSO .zip .ZIP .7z .7Z .chd .CHD</extension>
+    <extension>.cue .iso .cso .zip .7z .chd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
           <core>genesis_plus_gx</core>
           <core>genesis_plus_gx_wide</core>
-          <core>picodrive</core>
+          <core incompatible_extensions=".chd">picodrive</core>
         </cores>
       </emulator>
       <emulator name="kega-fusion">
@@ -587,7 +587,7 @@
     <release>1994</release>
     <hardware>extension</hardware>
     <path>~\..\roms\sega32x</path>
-    <extension>.32x .smd .bin .md .32X .SMD .BIN .MD .zip .ZIP .7z .7Z</extension>
+    <extension>.32x .smd .bin .md .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -611,7 +611,7 @@
     <release>1995</release>
     <hardware>console</hardware>
     <path>~\..\roms\saturn</path>
-    <extension>.zip .cue .toc .m3u .ccd .chd .CUE .TOC .M3U .CCD .CHD .iso .ISO .cso .CSO .mdf .MDF .chd .CHD</extension>
+    <extension>.zip .cue .toc .m3u .ccd .chd .iso .cso .mdf .chd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -631,7 +631,7 @@
     <release>1998</release>
     <hardware>console</hardware>
     <path>~\..\roms\dreamcast</path>
-    <extension>.mds .MDS .mdf .MDF .cue .CUE .cdi .CDI .gdi .GDI .chd .CHD .m3u .M3U</extension>
+    <extension>.mds .mdf .cue .cdi .gdi .chd .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -661,7 +661,7 @@
     <release>1986</release>
     <hardware>console</hardware>
     <path>~\..\roms\fds</path>
-    <extension>.nes .NES .fds .FDS .zip .ZIP .7z .7Z</extension>
+    <extension>.nes .fds .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -686,7 +686,7 @@
     <release>1983</release>
     <hardware>console</hardware>
     <path>~\..\roms\nes</path>
-    <extension>.fds .FDS .nes .wad .WAD .NES .zip .ZIP .7z .7Z</extension>
+    <extension>.fds .nes .wad .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -716,7 +716,7 @@
     <hardware>console</hardware>
     <release>1990</release>
     <path>~\..\roms\snes</path>
-    <extension>.smc .SMC .fig .FIG .sfc .SFC .gd3 .GD3 .gd7 .GD7 .dx2 .DX2 .bsx .BSX .swc .SWC .rom .wad .WAD .ROM .zip .ZIP .7z .7Z</extension>
+    <extension>.smc .fig .sfc .gd3 .gd7 .dx2 .bsx .swc .rom .wad .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -746,7 +746,7 @@
     <hardware>extension</hardware>
     <release>2012</release>
     <path>~\..\roms\snes-msu</path>
-    <extension>.smc .sfc .SMC .SFC .bml .BML .m3u .M3U</extension>
+    <extension>.smc .sfc .bml .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -768,7 +768,7 @@
     <hardware>console</hardware>
     <fullname>Satellaview</fullname>
     <path>~\..\roms\satellaview</path>
-    <extension>.st .ST .fig .FIG .bs .BS .smc .SMC .sfc .SFC .zip .ZIP .7z .7Z</extension>
+    <extension>.st .fig .bs .smc .sfc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -788,7 +788,7 @@
     <hardware>console</hardware>
     <fullname>SuFami Turbo</fullname>
     <path>~\..\roms\sufami</path>
-    <extension>.st .ST .fig .FIG .bs .BS .smc .SMC .sfc .SFC .zip .ZIP .7z .7Z</extension>
+    <extension>.st .fig .bs .sm .sfc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -808,7 +808,7 @@
     <release>1995</release>
     <hardware>console</hardware>
     <path>~\..\roms\virtualboy</path>
-    <extension>.vb .vboy .bin .zip .7z .VB .VBOY .BIN .ZIP .7Z</extension>
+    <extension>.vb .vboy .bin .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -827,7 +827,7 @@
     <release>1996</release>
     <hardware>console</hardware>
     <path>~\..\roms\n64</path>
-    <extension>.v64 .z64 .n64 .wad .WAD .V64 .Z64 .N64 .zip .ZIP .7z</extension>
+    <extension>.v64 .z64 .n64 .wad .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -848,7 +848,7 @@
     <release>1999</release>
     <hardware>console</hardware>
     <path>~\..\roms\64dd</path>
-    <extension>.v64 .z64 .n64 .wad .WAD .V64 .Z64 .N64 .zip .ZIP .7z .ndd .NDD</extension>
+    <extension>.v64 .z64 .n64 .wad .zip .7z .ndd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -868,7 +868,7 @@
     <release>2001</release>
     <hardware>console</hardware>
     <path>~\..\roms\gamecube</path>
-    <extension>.iso .ciso .gcm .gcz .rvz .ISO .CSO .GCM .GCZ .RVZ</extension>
+    <extension>.iso .ciso .gcm .gcz .rvz</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="dolphin">
@@ -892,7 +892,7 @@
     <release>2006</release>
     <hardware>console</hardware>
     <path>~\..\roms\wii</path>
-    <extension>.gcz .iso .ciso .wbfs .wad .rvz .GCZ .ISO .CSO .WBFS .WAD .RVZ</extension>
+    <extension>.gcz .iso .ciso .wbfs .wad .rvz</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="dolphin">
@@ -916,7 +916,7 @@
     <release>2010</release>
     <hardware>console</hardware>
     <path>~\..\roms\wiiu</path>
-    <extension>.iso .rpx .wud .wux .m3u .ISO .RPX .WUD .WUX .M3U</extension>
+    <extension>.iso .rpx .wud .wux .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="cemu"/>
@@ -930,7 +930,7 @@
     <manufacturer>Nintendo</manufacturer>
     <release>2017</release>
     <path>~\..\roms\switch</path>
-    <extension>.nso .nro .nca .xci .nsp .kip .NSO .NRO .NCA .XCI .NSP .KIP</extension>
+    <extension>.nso .nro .nca .xci .nsp .kip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="yuzu"/>
@@ -946,7 +946,7 @@
     <release>1987</release>
     <hardware>console</hardware>
     <path>~\..\roms\pcengine</path>
-    <extension>.pce .bin .zip .7z .wad .WAD .PCE .BIN .ZIP .7Z</extension>
+    <extension>.pce .bin .zip .7z .wad</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -972,7 +972,7 @@
     <release>1988</release>
     <hardware>console</hardware>
     <path>~\..\roms\pcenginecd</path>
-    <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .cso .CSO .img .IMG .bin .BIN .chd .CHD .zip .ZIP .7z .7Z</extension>
+    <extension>.pce .cue .ccd .iso .cso .img .bin .chd .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1023,7 +1023,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\pcfx</path>
-    <extension>.cue .ccd .toc .chd .CUE .CCD .TOC .CHD</extension>
+    <extension>.cue .ccd .toc .chd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1042,13 +1042,14 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\psx</path>
-    <extension>.cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO .cso .CSO</extension>
+    <extension>.cue .img .mdf .pbp .toc .cbn .m3u .ccd .chd .zip .7z .iso .cso</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
           <core>mednafen_psx_hw</core>
           <core>pcsx_rearmed</core>
+          <core>duckstation</core>
         </cores>
       </emulator>
       <emulator name="duckstation"/>
@@ -1063,21 +1064,15 @@
     <release>2000</release>
     <hardware>console</hardware>
     <path>~\..\roms\ps2</path>
-    <extension>.iso .ISO .cso .CSO .bin .BIN .mdf .MDF .gz .GZ</extension>
+    <extension>.iso .cs .bin .mdf .gz</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-      <emulator name="pcsx2">
+      <emulator name="pcsx2"/>
+      <emulator name="libretro">
         <cores>
-          <core>avx2</core>
-          <core>sse2</core>
-          <core>sse4</core>
+          <core>play</core>
         </cores>
       </emulator>
-      <!--<emulator name="libretro">
-        <cores>
-          <core>pcsx2</core>
-        </cores>
-      </emulator>-->
     </emulators>
     <platform>ps2</platform>
     <theme>ps2</theme>
@@ -1089,7 +1084,8 @@
     <release>2006</release>
     <hardware>console</hardware>
     <path>~\..\roms\ps3</path>
-    <extension>.m3u .M3U</extension>
+    <extension>.m3u .ps3</extension>
+    <!-- Place uncompressed disc images (including PS3_GAME folder) in a folder with extension .ps3 -->
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="rpcs3"/>
@@ -1104,11 +1100,19 @@
     <release>2001</release>
     <hardware>console</hardware>
     <path>~\..\roms\xbox</path>
-    <extension>.xbe .XBE .iso .ISO .pc .PC</extension>
+    <extension>.xbe .iso .pc</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
-      <emulator name="xemu"/>
-      <emulator name="cxbx"/>
+      <emulator name="xemu">
+        <cores>
+          <core incompatible_extensions=".xbe">xemu</core>
+        </cores>
+      </emulator>
+      <emulator name="cxbx">
+        <cores>
+          <core incompatible_extensions=".iso">cxbx</core>
+        </cores>
+      </emulator>
     </emulators>
     <platform>xbox</platform>
     <theme>xbox</theme>
@@ -1120,7 +1124,7 @@
     <release>2005</release>
     <hardware>console</hardware>
     <path>~\..\roms\xbox360</path>
-    <extension>.iso .ISO .xex .XEX .xcp .XCP .m3u .M3U</extension>
+    <extension>.iso .xex .xcp .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="xenia">
@@ -1140,7 +1144,7 @@
     <release>1993</release>
     <hardware>console</hardware>
     <path>~\..\roms\3do</path>
-    <extension>.m3u .cue .iso .chd .CUE .ISO .CHD</extension>
+    <extension>.m3u .cue .iso .chd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1153,13 +1157,21 @@
     <theme>3do</theme>
   </system>
   <system>
+    <fullname>Amiga</fullname>
+    <name>amiga</name>
+    <manufacturer>Commodore</manufacturer>
+    <hardware>computer</hardware>
+    <platform>amiga</platform>
+    <theme>amiga</theme>
+  </system>
+  <system>
     <name>amiga500</name>
     <fullname>Amiga OCS/ECS</fullname>
     <manufacturer>Commodore</manufacturer>
     <release>1987</release>
     <hardware>console</hardware>
     <path>~\..\roms\amiga500</path>
-    <extension>.zip .ZIP .adf .ADF .uae .UAE .ipf .IPF .dms .DMS .adz .ADZ .lha .LHA .rp9 .RP9 .uae .UAE .m3u .M3U .zip .ZIP .7z .7Z</extension>
+    <extension>.zip .adf .uae .ipf .dms .adz .lha .rp9 .uae .m3u .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1181,7 +1193,7 @@
     <release>1992</release>
     <hardware>console</hardware>
     <path>~\..\roms\amiga1200</path>
-    <extension>.zip .adf .uae .UAE .ipf .IPF .dms .DMS .adz .ADZ .lha .LHA .rp9 .RP9  .uae .UAE .m3u .M3U .zip .ZIP .7z .7Z</extension>
+    <extension>.zip .adf .uae .ipf .dms .adz .lha .rp9 .uae .m3u .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1203,7 +1215,7 @@
     <release>1994</release>
     <hardware>computer</hardware>
     <path>~\..\roms\amiga4000</path>
-    <extension>.zip .uae .lha .adf .Adf .ADF .uae .rp9 .RP9  .uae .UAE .m3u .M3U .zip .ZIP .7z .7Z</extension>
+    <extension>.zip .uae .lha .adf .uae .rp9 .uae .m3u .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>amiga</platform>
     <theme>amiga4000</theme>
@@ -1225,7 +1237,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\amigacd32</path>
-    <extension>.iso .cso .cue .zip .lha .ISO .CSO .CUE .ZIP .LHA .rp9 .RP9 .chd .CHD .ccd .CCD .nrg .NRG .mds .MDS</extension>
+    <extension>.iso .cso .cue .zip .lha .rp9 .chd .ccd .nrg .mds</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1249,7 +1261,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\amigacdtv</path>
-    <extension>.cue .CUE .iso .ISO .cso .CSO .rp9 .RP9 .ccd .CCD .nrg .NRG .mds .MDS</extension>
+    <extension>.cue .iso .cso .rp9 .ccd .nrg .mds</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1270,7 +1282,7 @@
     <release>1984</release>
     <hardware>computer</hardware>
     <path>~\..\roms\amstradcpc</path>
-    <extension>.dsk .sna .tap .cdt .voc .m3u .zip .DSK .SNA .TAP .CDT .VOC .M3U .ZIP</extension>
+    <extension>.dsk .sna .tap .cdt .voc .m3u .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1290,7 +1302,7 @@
     <release>1991</release>
     <hardware>computer</hardware>
     <path>~\..\roms\gx4000</path>
-    <extension>.dsk .DSK .m3u .M3U .cpr .CPR .zip .ZIP .7z .7Z</extension>
+    <extension>.dsk .m3u .cpr .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1347,7 +1359,7 @@
     <release>1979</release>
     <hardware>console</hardware>
     <path>~\..\roms\atari800</path>
-    <extension>.rom .ROM .xfd .XFD .atr .ATR .atx .ATX .cdm .CDM .cas .CAS .bin .BIN .a52 .A52 .xex .XEX .zip .ZIP .7z .7Z</extension>
+    <extension>.rom .xfd .atr .atx .cdm .cas .bin .a52 .xex .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1366,7 +1378,7 @@
     <release>1977</release>
     <hardware>console</hardware>
     <path>~\..\roms\atari2600</path>
-    <extension>..7z .a26 .bin .gz .rom .zip .7Z .A26 .BIN .GZ .ROM .ZIP</extension>
+    <extension>.7z .a26 .bin .gz .rom .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1386,7 +1398,7 @@
     <release>1982</release>
     <hardware>console</hardware>
     <path>~\..\roms\atari5200</path>
-    <extension>.rom .ROM .xfd .XFD .atr .ATR .atx .ATX .cdm .CDM .cas .CAS .bin .BIN .a52 .A52 .xex .XEX .zip .ZIP .7z .7Z</extension>
+    <extension>.rom .xfd .atr .atx .cdm .cas .bin .a52 .xex .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1406,7 +1418,7 @@
     <release>1986</release>
     <hardware>console</hardware>
     <path>~\..\roms\atari7800</path>
-    <extension>.a78 .A78 .bin .BIN .zip .ZIP .7z .7Z</extension>
+    <extension>.a78 .bin .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1425,7 +1437,7 @@
     <release>1985</release>
     <hardware>console</hardware>
     <path>~\..\roms\atarist</path>
-    <extension>.st .msa .stx .dim .ipf .m3u .zip .ST .MSA .STX .DIM .IPF .M3U .ZIP</extension>
+    <extension>.st .msa .stx .dim .ipf .m3u .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1444,7 +1456,7 @@
     <release>1993</release>
     <fullname>Jaguar</fullname>
     <path>~\..\roms\jaguar</path>
-    <extension>.zip .7z .j64 .jag .rom .abs .cof .bin .prg .ZIP .7Z .J64 .JAG .ROM .ABS .COF .BIN .PRG</extension>
+    <extension>.zip .7z .j64 .jag .rom .abs .cof .bin .prg</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1482,7 +1494,7 @@
     <release>1982</release>
     <hardware>console</hardware>
     <path>~\..\roms\colecovision</path>
-    <extension>.rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u .zip .ROM .RI .MX1 .MX2 .COL .DSK .CAS .SG .SC .M3U .ZIP</extension>
+    <extension>.rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1502,7 +1514,7 @@
     <release>1980</release>
     <hardware>computer</hardware>
     <path>~\..\roms\c20</path>
-    <extension>.a0 .A0 .b0 .B0 .crt .CRT .d64 .D64 .d81 .D81 .prg .PRG .tap .TAP .t64 .T64 .zip .ZIP</extension>
+    <extension>.a0 .b0 .crt .d64 .d81 .prg .tap .t64 .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1521,7 +1533,7 @@
     <release>1982</release>
     <hardware>computer</hardware>
     <path>~\..\roms\c64</path>
-    <extension>.crt .d64 .g64 .t64 .zip .CRT .D64 .G64 .T64 .ZIP</extension>
+    <extension>.crt .d64 .g64 .t64 .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1546,7 +1558,7 @@
     <release>1985</release>
     <hardware>computer</hardware>
     <path>~\..\roms\c128</path>
-    <extension>.d64 .D64 .d81 .D81 .prg .PRG .lnx .LNX .zip .ZIP</extension>
+    <extension>.d64 .d81 .prg .lnx .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1565,7 +1577,7 @@
     <hardware>console</hardware>
     <fullname>Mattel Intellivision</fullname>
     <path>~\..\roms\intellivision</path>
-    <extension>.int .INT .bin .BIN .rom .ROM .zip .ZIP .7z .7Z</extension>
+    <extension>.int .bin .rom .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1603,7 +1615,7 @@
     <release>1983</release>
     <hardware>computer</hardware>
     <path>~\..\roms\msx1</path>
-    <extension>.zip .7z .rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u .ZIP .7Z .ROM .RI .MX1 .MX2 .COL .DSK .CAS .SG .SC .M3U</extension>
+    <extension>.zip .7z .rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1624,7 +1636,7 @@
     <release>1985</release>
     <hardware>computer</hardware>
     <path>~\..\roms\msx2</path>
-    <extension>.zip .7z .rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u .ZIP .7Z .ROM .RI .MX1 .MX2 .COL .DSK .CAS .SG .SC .M3U</extension>
+    <extension>.zip .7z .rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1645,7 +1657,7 @@
     <release>1988</release>
     <hardware>computer</hardware>
     <path>~\..\roms\msx2+</path>
-    <extension>.zip .7z .rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u .ZIP .7Z .ROM .RI .MX1 .MX2 .COL .DSK .CAS .SG .SC .M3U</extension>
+    <extension>.zip .7z .rom .ri .mx1 .mx2 .col .dsk .cas .sg .sc .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1666,7 +1678,7 @@
     <release>1988</release>
     <hardware>computer</hardware>
     <path>~\..\roms\spectravideo</path>
-    <extension>.cas .bin .zip .7z .m3u .CAS .BIN .ZIP .7Z .M3U</extension>
+    <extension>.cas .bin .zip .7z .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>spectravideo</platform>
     <theme>spectravideo</theme>
@@ -1704,7 +1716,7 @@
     <release>1981</release>
     <hardware>computer</hardware>
     <path>~\..\roms\pc88</path>
-    <extension>.d88 .u88 .m3u .D88 .U88 .M3U</extension>
+    <extension>.d88 .u88 .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1723,7 +1735,7 @@
     <release>1982</release>
     <hardware>computer</hardware>
     <path>~\..\roms\pc98</path>
-    <extension>.d98 .D98 .zip .ZIP .98d .98D .fdi .FDI .fdd .FDD .2hd .2HD .tfd .TFD .d88 .D88 .88d .88D .hdm .HDM .xdf .XDF .dup .DUP .cmd .CMD .hdi .HDI .thd .THD .nhd .NHD .hdd .HDD .hdn .HDN</extension>
+    <extension>.d98 .zip .98d .fdi .fdd .2hd .tfd .d88 .88d .hdm .xdf .dup .cmd .hdi .thd .nhd .hdd .hdn</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1737,13 +1749,32 @@
     <theme>pc98</theme>
   </system>
   <system>
+    <fullname>Multivision</fullname>
+    <name>multivision</name>
+    <manufacturer>Othello</manufacturer>
+    <release>1983</release>
+    <hardware>console</hardware>
+    <path>~\..\roms\multivision</path>
+    <extension>.zip .bin</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>sg-1000</platform>
+    <theme>multivision</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>gearsystem</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
     <name>samcoupe</name>
     <fullname>Samcoupé</fullname>
-    <manufacturer>MGT</manufacturer>
+    <manufacturer>Miles Gordon Technology</manufacturer>
     <release>1989</release>
     <hardware>computer</hardware>
     <path>~\..\roms\samcoupe</path>
-    <extension>.dsk .mgt .sbt .sad .DSK .MGT .SBT .SAD</extension>
+    <extension>.dsk .mgt .sbt .sad</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="simcoupe">
@@ -1762,7 +1793,7 @@
     <release>1987</release>
     <hardware>computer</hardware>
     <path>~\..\roms\x68000</path>
-    <extension>.dim .DIM .img .IMG .d88 .D88 .88d .88D .hdm .HDM .dup .DUP .2hd .2HD .xdf .XDF .hdf .HDF .cmd .CMD .m3u .M3U .zip .ZIP .7z .7Z</extension>
+    <extension>.dim .img .d88 .88d .hdm .dup .2hd .xdf .hdf .cmd .m3u .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1781,7 +1812,7 @@
     <release>1982</release>
     <hardware>computer</hardware>
     <path>~\..\roms\x1</path>
-    <extension>.dx1 .zip .2d .2hd .tfd .d88 .88d .hdm .xdf .dup .cmd .7z .DX1 .ZIP .2D .2HD .TFD .D88 .88D .HDM .XDF .DUP .CMD .7Z</extension>
+    <extension>.dx1 .zip .2d .2hd .tfd .d88 .88d .hdm .xdf .dup .cmd .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1800,7 +1831,7 @@
     <release>1984</release>
     <hardware>computer</hardware>
     <path>~\..\roms\thomson</path>
-    <extension>.zip .7z .fd .sap .k7 .rom .m7 .m5 .ZIP .7Z .FD .SAP .K7 .ROM .M7 .M5</extension>
+    <extension>.zip .7z .fd .sap .k7 .rom .m7 .m5</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1819,7 +1850,7 @@
     <release>1982</release>
     <hardware>computer</hardware>
     <path>~\..\roms\vectrex</path>
-    <extension>.bin .BIN .gam .GAM .vec .VEC .zip .ZIP .7z .7Z</extension>
+    <extension>.bin .gam .vec .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1834,11 +1865,11 @@
   <system>
     <name>odyssey2</name>
     <fullname>Odyssey² - Videopac</fullname>
-    <manufacturer>Magnavox - Philips</manufacturer>
+    <manufacturer>Philips</manufacturer>
     <release>1978</release>
     <hardware>computer</hardware>
     <path>~\..\roms\o2em</path>
-    <extension>.bin .zip .7z .BIN .ZIP .7Z</extension>
+    <extension>.bin .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1857,7 +1888,7 @@
     <release>1981</release>
     <hardware>computer</hardware>
     <path>~\..\roms\zx81</path>
-    <extension>tzx .TZX .tap .TAP .z80 .Z80 .rzx .RZX .scl .SCL .trd .TRD .zip .ZIP .7z .7Z</extension>
+    <extension>tzx .tap .z80 .rzx .scl .trd .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1878,7 +1909,7 @@
     <release>1982</release>
     <hardware>computer</hardware>
     <path>~\..\roms\zxspectrum</path>
-    <extension>tzx .TZX .tap .TAP .z80 .Z80 .rzx .RZX .scl .SCL .trd .TRD .zip .ZIP .7z .7Z</extension>
+    <extension>tzx .tap .z80 .rzx .scl .trd .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1898,7 +1929,7 @@
     <hardware>portable</hardware>
     <release>1989</release>
     <path>~\..\roms\lynx</path>
-    <extension>.lnx .LNX .zip .o .7z .LNX .LNX .ZIP .O .7Z</extension>
+    <extension>.lnx .zip .o .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1918,7 +1949,7 @@
     <release>1990</release>
     <hardware>portable</hardware>
     <path>~\..\roms\gamegear</path>
-    <extension>.gg .bin .GG .BIN .zip .ZIP .7z .7Z</extension>
+    <extension>.gg .bin .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1939,7 +1970,7 @@
     <release>1980</release>
     <hardware>portable</hardware>
     <path>~\..\roms\gameandwatch</path>
-    <extension>.mgw .MGW .zip .ZIP .7z .7Z</extension>
+    <extension>.mgw .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1959,7 +1990,7 @@
     <release>1989</release>
     <hardware>portable</hardware>
     <path>~\..\roms\gb</path>
-    <extension>.gb .GB .zip .ZIP .7z .7Z</extension>
+    <extension>.gb .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -1981,7 +2012,7 @@
     <release>1989</release>
     <hardware>portable</hardware>
     <path>~\..\roms\gb2players</path>
-    <extension>.gb .GB .zip .ZIP .7z .7Z</extension>
+    <extension>.gb .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2000,7 +2031,7 @@
     <release>1998</release>
     <hardware>portable</hardware>
     <path>~\..\roms\gbc</path>
-    <extension>.gbc .GBC .zip .ZIP .7z .7Z</extension>
+    <extension>.gbc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2020,7 +2051,7 @@
     <manufacturer>Nintendo</manufacturer>
     <hardware>portable</hardware>
     <path>~\..\roms\gbc2players</path>
-    <extension>.gbc .GBC .zip .ZIP .7z .7Z</extension>
+    <extension>.gbc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2039,7 +2070,7 @@
     <release>2001</release>
     <hardware>portable</hardware>
     <path>~\..\roms\gba</path>
-    <extension>.gba .GBA .zip .ZIP .7z .7Z</extension>
+    <extension>.gba .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2064,7 +2095,7 @@
     <release>2001</release>
     <hardware>portable</hardware>
     <path>~\..\roms\pokemini</path>
-    <extension>.min .MIN .zip .ZIP .7z .7Z</extension>
+    <extension>.min .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2083,7 +2114,7 @@
     <release>2004</release>
     <hardware>portable</hardware>
     <path>~\..\roms\nds</path>
-    <extension>.nds .NDS .zip .ZIP .7z</extension>
+    <extension>.nds .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2104,7 +2135,7 @@
     <release>2011</release>
     <hardware>portable</hardware>
     <path>~\..\roms\3ds</path>
-    <extension>.3ds .3dsx .elf .axf .cci .cxi .app .3DS .3DSX .ELF .AXF .CCI .CXI .APP</extension>
+    <extension>.3ds .3dsx .elf .axf .cci .cxi .app</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2128,7 +2159,7 @@
     <release>2004</release>
     <hardware>portable</hardware>
     <path>~\..\roms\psp</path>
-    <extension>.iso .ISO .cso .CSO .pbp .PBP .elf .ELF .prx .PRX</extension>
+    <extension>.iso .cso .pbp .elf .prx</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2148,7 +2179,7 @@
     <release>1998</release>
     <hardware>portable</hardware>
     <path>~\..\roms\ngp</path>
-    <extension>.ngp .ngc .zip .ZIP .7z</extension>
+    <extension>.ngp .ngc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2168,7 +2199,7 @@
     <release>1999</release>
     <hardware>portable</hardware>
     <path>~\..\roms\ngpc</path>
-    <extension>.ngp .ngc .zip .ZIP .7z</extension>
+    <extension>.ngp .ngc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2188,7 +2219,7 @@
     <release>1992</release>
     <hardware>portable</hardware>
     <path>~\..\roms\supervision</path>
-    <extension>.sv .SV .zip .ZIP .7z .7Z</extension>
+    <extension>.sv .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2207,7 +2238,7 @@
     <release>1999</release>
     <hardware>portable</hardware>
     <path>~\..\roms\wswan</path>
-    <extension>.ws .WS .zip .ZIP .7z .7Z</extension>
+    <extension>.ws .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2226,7 +2257,7 @@
     <release>2000</release>
     <hardware>portable</hardware>
     <path>~\..\roms\wswanc</path>
-    <extension>.wsc .WSC .zip .ZIP .7z .7Z</extension>
+    <extension>.wsc .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2245,7 +2276,7 @@
     <hardware>port</hardware>
     <release>1987</release>
     <path>~\..\roms\scummvm</path>
-    <extension>.scummvm .SCUMMVM</extension>
+    <extension>.scummvm</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2264,7 +2295,7 @@
     <release/>
     <name>ports</name>
     <path>~\..\roms\ports</path>
-    <extension>.libretro</extension>
+    <extension>.libretro .game</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -rom %ROM%</command>
     <platform>ports</platform>
     <theme>ports</theme>
@@ -2280,7 +2311,7 @@
     <release>2008</release>
     <hardware>port</hardware>
     <path>~\..\roms\love</path>
-    <extension>.zip .7z .lua .love .lutro .exe .ZIP .LUA .LOVE .LUTRO .7Z .EXE</extension>
+    <extension>.zip .7z .lua .love .lutro .exe</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="love"/>
@@ -2295,7 +2326,7 @@
     <release/>
     <hardware>port</hardware>
     <path>~\..\roms\lutro</path>
-    <extension>.love .LOVE .lua .LUA .lutro .LUTRO .zip .ZIP .7z .7Z</extension>
+    <extension>.love .lua .lutro .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2314,7 +2345,7 @@
     <release/>
     <hardware>port</hardware>
     <path>~\..\roms\easyrpg</path>
-    <extension>.zip .easyrpg .ZIP .EASYRPG .lbd .LBD</extension>
+    <extension>.zip .easyrpg .lbd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2334,7 +2365,7 @@
     <manufacturer>Ports</manufacturer>
     <release/>
     <path>~\..\roms\prboom</path>
-    <extension>.wad .iwad .pwad .WAD .IWAD .PWAD</extension>
+    <extension>.wad .iwad .pwad</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2355,7 +2386,7 @@
     <release/>
     <manufacturer>Ports</manufacturer>
     <path>~\..\roms\tyrquake</path>
-    <extension>.pak .PAK</extension>
+    <extension>.pak</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2390,14 +2421,32 @@
     <group>ports</group>
   </system>
   <system>
+    <fullname>Cannonball Outrun</fullname>
+    <name>cannonball</name>
+    <manufacturer>Ports</manufacturer>
+    <release/>
+    <hardware>port</hardware>
+    <path>~\..\roms\cannonball</path>
+    <!-- Place OutRun Revision B ROMs in this directory & create empty CannonBall.game file in this directory -->
+    <extension>.game</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -rom %ROM%</command>
+    <platform>ports</platform>
+    <theme>cannonball</theme>
+    <group>ports</group>
+    <emulators>
+      <emulator name="libretro"/>
+    </emulators>
+  </system>
+  <system>
     <name>mugen</name>
     <fullname>MUGEN</fullname>
     <manufacturer>Ports</manufacturer>
     <release/>
     <hardware>port</hardware>
     <path>~\..\roms\mugen</path>
-    <extension>.exe .bat .cmd .lnk .url .EXE .BAT .CMD .LNK .URL</extension>
-    <command>"%ROM_RAW%"</command>
+    <extension>.pc .m3u .exe .bat .cmd .lnk .url</extension>
+    <!-- Place games in a folder with .pc extension & create an autorun.cmd file with the exe name -->
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>pc</platform>
     <theme>mugen</theme>
   </system>
@@ -2408,7 +2457,7 @@
     <manufacturer>Ports</manufacturer>
     <release/>
     <path>~\..\roms\openbor</path>
-    <extension>.pak .PAK .exe .EXE</extension>
+    <extension>.pak .exe</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="openbor">
@@ -2428,7 +2477,7 @@
     <release/>
     <hardware>port</hardware>
     <path>~\..\roms\solarus</path>
-    <extension>.solarus .SOLARUS .zip .ZIP</extension>
+    <extension>.solarus .zip</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="solarus"/>
@@ -2458,7 +2507,7 @@
     <release>1981</release>
     <hardware>computer</hardware>
     <path>~\..\roms\dos</path>
-    <extension>.dosbox .pc .dos .dosz .d.zip .zip .m3u8 .bat .cmd .DOSBOX .PC .DOS .DOSZ .D.ZIP .ZIP .M3U8 .BAT .CMD</extension>
+    <extension>.dosbox .pc .dos .dosz .d.zip .zip .m3u8 .bat .cmd</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2495,7 +2544,7 @@
     <release>2000</release>
     <hardware>pinball</hardware>
     <path>~\..\roms\vpinball</path>
-    <extension>.vpx .VPX</extension>
+    <extension>.vpx</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="vpinball">
@@ -2514,7 +2563,7 @@
     <release>2000</release>
     <hardware>pinball</hardware>
     <path>~\..\roms\fpinball</path>
-    <extension>.fpt .FPT</extension>
+    <extension>.fpt</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="fpinball">
@@ -2534,7 +2583,7 @@
     <release>2017</release>
     <hardware>pinball</hardware>
     <path>~\..\roms\pinballfx3</path>
-    <extension>.pxp .PXP</extension>
+    <extension>.pxp</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="pinballfx3">
@@ -2554,7 +2603,7 @@
     <release>2015</release>
     <hardware>console</hardware>
     <path>~\..\roms\pico8</path>
-    <extension>.png .p8 .PNG .P8 .exe .EXE</extension>
+    <extension>.png .p8 .exe</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2568,13 +2617,32 @@
     <theme>pico8</theme>
   </system>
   <system>
+    <fullname>Uzebox</fullname>
+    <name>uzebox</name>
+    <manufacturer>Fantasy Console</manufacturer>
+    <release>2017</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\uzebox</path>
+    <extension>.uze .zip .7z</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <platform>uzebox</platform>
+    <theme>uzebox</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>uzem</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
     <name>tic80</name>
     <fullname>TIC-80</fullname>
     <manufacturer>Fantasy Console</manufacturer>
     <release>2016</release>
     <hardware>console</hardware>
     <path>~\..\roms\tic80</path>
-    <extension>.tic .TIC</extension>
+    <extension>.tic</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
@@ -2594,7 +2662,7 @@
     <hardware>console</hardware>
     <path>~\..\roms\cdi</path>
     <extension>.chd .cue .toc .nrg .gdi .iso .cdr</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="mame64">
         <cores>
@@ -2611,14 +2679,14 @@
     <theme>cdi</theme>
   </system>
   <system>
-    <fullname>Adventure Vision</fullname>
+    <fullname>Entex Adventure Vision</fullname>
     <name>advision</name>
     <path>~\..\roms\advision</path>
-    <manufacturer>Entex</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1982</release>
     <hardware>console</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>advision</platform>
     <theme>advision</theme>
     <emulators>
@@ -2642,7 +2710,7 @@
     <release>2002</release>
     <hardware>console</hardware>
     <extension>.zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>tvgames</platform>
     <theme>tvgames</theme>
     <emulators>
@@ -2662,11 +2730,11 @@
     <fullname>Mega Duck</fullname>
     <name>megaduck</name>
     <path>~\..\roms\megaduck</path>
-    <manufacturer>Welback Holdings</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1993</release>
     <hardware>portable</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>megaduck</platform>
     <theme>megaduck</theme>
     <emulators>
@@ -2690,7 +2758,7 @@
     <release>1983</release>
     <hardware>console</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>pv1000</platform>
     <theme>pv1000</theme>
     <emulators>
@@ -2714,7 +2782,7 @@
     <release>1982</release>
     <hardware>console</hardware>
     <extension>.bin .rom .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>creativision</platform>
     <theme>creativision</theme>
     <emulators>
@@ -2731,14 +2799,14 @@
     </emulators>
   </system>
   <system>
-    <fullname>Game.com</fullname>
+    <fullname>Tiger Electronics Game.com</fullname>
     <name>gamecom</name>
     <path>~\..\roms\gamecom</path>
-    <manufacturer>Tiger Electronics</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1997</release>
     <hardware>portable</hardware>
     <extension>.bin .zip .7z .tgc</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>gamecom</platform>
     <theme>gamecom</theme>
     <emulators>
@@ -2755,14 +2823,14 @@
     </emulators>
   </system>
   <system>
-    <fullname>Game Pocket Computer</fullname>
+    <fullname>Epoch Game Pocket Computer</fullname>
     <name>gamepock</name>
     <path>~\..\roms\gamepock</path>
-    <manufacturer>Epoch</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1984</release>
     <hardware>portable</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>gamepock</platform>
     <theme>gamepock</theme>
     <emulators>
@@ -2786,7 +2854,7 @@
     <hardware>computer</hardware>
     <path>~\..\roms\fm7</path>
     <extension>.wav .t77 .mfi .dfi .hfe .mfm .td0 .imd .d77 .d88 .1dd .cqm .cqi .dsk .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="mame64">
         <cores>
@@ -2805,12 +2873,12 @@
   <system>
     <name>apfm1000</name>
     <fullname>APF M-1000</fullname>
-    <manufacturer>APF Electronics</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1978</release>
     <hardware>console</hardware>
     <path>~\..\roms\apfm1000</path>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
@@ -2834,7 +2902,7 @@
     <hardware>computer</hardware>
     <path>~\..\roms\bbcmicro</path>
     <extension>.zip .7zip</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
@@ -2850,6 +2918,7 @@
     <platform>bbcmicro</platform>
     <theme>bbcmicro</theme>
   </system>
+  <!--
   <system>
     <name>adam</name>
     <fullname>Coleco ADAM</fullname>
@@ -2858,31 +2927,32 @@
     <hardware>computer</hardware>
     <path>~\..\roms\adam</path>
     <extension>.wav .ddp .mfi .dfi .hfe .mfm .td0 .imd .d77 .d88 .1dd .cqm .cqi .dsk .rom .col .bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
-    <emulators>
-      <emulator name="libretro">
-        <cores>
-          <core>mame</core>
-        </cores>
-      </emulator>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators> 
       <emulator name="mame64">
         <cores>
           <core>adam</core>
         </cores>
       </emulator>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>     
     </emulators>
     <platform>adam</platform>
     <theme>adam</theme>
   </system>
+  -->
   <system>
-    <fullname>Arcadia 2001</fullname>
+    <fullname>Emerson Arcadia 2001</fullname>
     <name>arcadia</name>
     <path>~\..\roms\arcadia</path>
-    <manufacturer>Emerson</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1982</release>
     <hardware>console</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>arcadia</platform>
     <theme>arcadia</theme>
     <emulators>
@@ -2899,14 +2969,14 @@
     </emulators>
   </system>
   <system>
-    <fullname>Game Master</fullname>
+    <fullname>Hartung Game Master</fullname>
     <name>gmaster</name>
     <path>~\..\roms\gmaster</path>
-    <manufacturer>Hartung</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1990</release>
     <hardware>portable</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>gmaster</platform>
     <theme>gmaster</theme>
     <emulators>
@@ -2923,14 +2993,14 @@
     </emulators>
   </system>
   <system>
-    <fullname>Astrocade</fullname>
+    <fullname>Bally Astrocade</fullname>
     <name>astrocde</name>
     <path>~\..\roms\astrocde</path>
-    <manufacturer>Bally</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1978</release>
     <hardware>console</hardware>
     <extension>.bin .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>astrocde</platform>
     <theme>astrocde</theme>
     <emulators>
@@ -2954,7 +3024,7 @@
     <hardware>computer</hardware>
     <path>~\..\roms\ti99</path>
     <extension>.zip</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
@@ -2973,12 +3043,12 @@
   <system>
     <name>tutor</name>
     <fullname>Tomy Tutor</fullname>
-    <manufacturer>Tomy</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>1983</release>
     <hardware>computer</hardware>
     <path>~\..\roms\tutor</path>
     <extension>.bin .wav .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
@@ -2996,13 +3066,13 @@
   </system>
   <system>
     <name>coco</name>
-    <fullname>Color Computer</fullname>
-    <manufacturer>Tandy Radio Shack</manufacturer>
+    <fullname>TRS-80 Color Computer</fullname>
+    <manufacturer>Tandy</manufacturer>
     <release>1980</release>
     <hardware>computer</hardware>
     <path>~\..\roms\coco</path>
     <extension>.wav .cas .ccc .rom .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
@@ -3026,7 +3096,7 @@
     <release>1987</release>
     <hardware>computer</hardware>
     <extension>.m3u .d88 .d77 .xdf .cue .iso .game .cd</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>fmtowns</platform>
     <theme>fmtowns</theme>
     <emulators>
@@ -3055,7 +3125,7 @@
     <release>1979</release>
     <hardware>portable</hardware>
     <extension>.mgw .zip .7z</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <platform>lcdgames</platform>
     <theme>lcdgames</theme>
     <emulators>
@@ -3080,7 +3150,7 @@
     <hardware>console</hardware>
     <path>~\..\roms\vsmile</path>
     <extension>.bin .zip</extension>
-    <command>%HOME%\emulatorLauncher.exe %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">
         <cores>
@@ -3095,7 +3165,79 @@
     </emulators>
     <platform>vsmile</platform>
     <theme>vsmile</theme>
-  </system>  
+  </system>
+  <system>
+    <name>camplynx</name>
+    <fullname>Camputers Lynx</fullname>
+    <manufacturer>Various</manufacturer>
+    <release>1983</release>
+    <hardware>computer</hardware>
+    <path>~\..\roms\camplynx</path>
+    <extension>.bin .zip</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>camplynx</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>camplynx</platform>
+    <theme>camplynx</theme>
+  </system>
+  <system>
+    <name>supracan</name>
+    <fullname>Super A'Can</fullname>
+    <manufacturer>Various</manufacturer>
+    <release>1995</release>
+    <hardware>console</hardware>
+    <path>~\..\roms\supracan</path>
+    <extension>.bin .zip</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>supracan</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>supracan</platform>
+    <theme>supracan</theme>
+  </system>
+  <system>
+    <name>gamate</name>
+    <fullname>Gamate</fullname>
+    <manufacturer>Various</manufacturer>
+    <release>1990</release>
+    <hardware>portable</hardware>
+    <path>~\..\roms\gamate</path>
+    <extension>.bin .zip</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+        </cores>
+      </emulator>
+      <emulator name="mame64">
+        <cores>
+          <core>gamate</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>gamate</platform>
+    <theme>gamate</theme>
+  </system>
   <!--<system>
     <name>medias</name>
     <fullname>Medias</fullname>
@@ -3154,7 +3296,7 @@
     <fullname>Screenshots</fullname>
     <manufacturer>Misc. System</manufacturer>
     <path>~\..\screenshots</path>
-    <extension>.jpg .jpeg .png  .bmp .psd .tga .gif .hdr .pic .ppm .pgm .JPG .JPEG .PNG  .BMP .PSD .TGA .GIF .HDR .PIC .PPM .PGM</extension>
+    <extension>.jpg .jpeg .png  .bmp .psd .tga .gif .hdr .pic .ppm .pgm</extension>
     <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">

--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -2661,7 +2661,7 @@
   <system>
     <fullname>Mega Duck</fullname>
     <name>megaduck</name>
-    <path>~\..\roms\tvgames</path>
+    <path>~\..\roms\megaduck</path>
     <manufacturer>Welback Holdings</manufacturer>
     <release>1993</release>
     <hardware>portable</hardware>


### PR DESCRIPTION
Add support for .ps3 folder extension for PS3
Add support for .pc folder extension and .m3u files for Mugen
Add .game extension to ports
Set incompatible_extensions to xbox cores
Move rarely used systems to "Various" manufacturer.