### PR TITLE
Correct LGPLv3 link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ I've written a script to facilitate retrobat packaging and compilation (WIP):
 RetroBat is a free and open source project. It should not be used for commercial purposes.
 It is done by a team of enthusiasts in their free time mainly for fun.
 
-All the code written by the RetroBat Team, unless covered by a licence from an upstream project, is given under the [LGPL v3 licence](http://www.gnu.org/licenses/lgpl-3.0.html/).
+All the code written by the RetroBat Team, unless covered by a licence from an upstream project, is given under the [LGPL v3 licence](https://www.gnu.org/licenses/lgpl-3.0.html).
 
 It is not allowed to sell RetroBat on a pre-installed machine or on any storage devices. RetroBat includes softwares which cannot be associated with any commercial activities.
 


### PR DESCRIPTION
This PR updates the link to the LGPLv3 license, as the current one leads to a 404
![image](https://user-images.githubusercontent.com/38186597/169147198-f3c32e88-b6e9-484e-961d-a33a23e0945a.png)
