### PR TITLE
Update es_systems_retrobat.cfg

### DIFF
--- a/system/templates/emulationstation/es_systems_retrobat.cfg
+++ b/system/templates/emulationstation/es_systems_retrobat.cfg
@@ -2110,6 +2110,25 @@
     <theme>gba</theme>
   </system>
   <system>
+    <name>gba2players</name>
+    <fullname>Game Boy Advance 2 players</fullname>
+    <manufacturer>Nintendo</manufacturer>
+    <release>2001</release>
+    <hardware>portable</hardware>
+    <path>~\..\roms\gba2players</path>
+    <extension>.gba .GBA .zip .ZIP .7z .7Z</extension>
+    <command>"%HOME%\emulatorLauncher.exe" %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
+      <emulators>
+      <emulator name="no$gba">
+        <cores>
+          <core>no$gba</core>
+        </cores>
+      </emulator>
+    </emulators>
+    <platform>gba</platform>
+    <theme>gba2players</theme>
+  </system>
+  <system>
     <name>pokemini</name>
     <fullname>Pokemon-Mini</fullname>
     <manufacturer>Nintendo</manufacturer>


### PR DESCRIPTION
gba2players with no$gba ému

example command line:

`NO$GBA.EXE /f /2 .\game.gba`

/f = fullscreen
/2 = force 2 players

