### PR TITLE
"esc" add on es_padtokey.cfg to exit no$gba emulator

### DIFF
--- a/system/templates/emulationstation/es_padtokey.cfg
+++ b/system/templates/emulationstation/es_padtokey.cfg
@@ -80,5 +80,8 @@
     </app>
     <app name="xemu">
         <input name="hotkey start" key="(%{KILL})"/>
+    </app>
+    <app name="nosgba">
+    	<input name="hotkey start" code="KEY_ESC"/>
     </app>	
 </padToKey>


### PR DESCRIPTION
"escape" key added on es_padtokey.cfg to exit no$gba emulator.