### PR TITLE
Update Project64.cfg

### DIFF
--- a/system/templates/project64/Project64.cfg
+++ b/system/templates/project64/Project64.cfg
@@ -1,6 +1,7 @@
 [Settings]
 Auto Full Screen=1
 Current Language=English
+Disk IPL ROM Path=..\..\bios\64DD_IPL.bin
 
 [Game Directory]
 Directory=..\..\roms\n64


### PR DESCRIPTION
Added path to BIOS for 64DD .ndd roms.
This allows .ndd to start with Project64.